### PR TITLE
add a configuration option for the "move the cursor to the end"

### DIFF
--- a/MailWrap.py
+++ b/MailWrap.py
@@ -365,21 +365,28 @@ class DocumentEditor(objc.Category(objc.runtime.DocumentEditor)):
                 else:
                     view.insertText_(attribution)
 
-            # Place the cursor at the end of the quoted text but before the
-            # signature if present, separated from the quoted text by a
-            # blank line.
+            if self._placeCursorAtEnd:
+                # Place the cursor at the end of the quoted text but before
+                # the signature if present, separated from the quoted text by
+                # a blank line.
 
-            signature = document.getElementById_('AppleMailSignature')
-            if signature:
-                range = document.createRange()
-                range.selectNode_(signature)
-                view.setSelectedDOMRange_affinity_(range, 0)
-                view.moveUp_(None)
+                signature = document.getElementById_('AppleMailSignature')
+                if signature:
+                    range = document.createRange()
+                    range.selectNode_(signature)
+                    view.setSelectedDOMRange_affinity_(range, 0)
+                    view.moveUp_(None)
+                else:
+                    view.moveToEndOfDocument_(None)
+
+                view.insertParagraphSeparator_(None)
+                view.insertParagraphSeparator_(None)
             else:
-                view.moveToEndOfDocument_(None)
+                view.moveToBeginningOfDocument_(None)
+                view.insertParagraphSeparator_(None)
+                view.insertParagraphSeparator_(None)
+                view.moveToBeginningOfDocument_(None)
 
-            view.insertParagraphSeparator_(None)
-            view.insertParagraphSeparator_(None)
             view.undoManager().removeAllActions()
             self.backEnd().setHasChanges_(False)
 
@@ -417,6 +424,11 @@ class MailWrap(objc.runtime.MVMailBundle):
             DocumentEditor._fixAttribution = False
         else:
             DocumentEditor._fixAttribution = True
+
+        if bundle.objectForInfoDictionaryKey_('PlaceCursorAtEnd') == False:
+            DocumentEditor._placeCursorAtEnd = False
+        else:
+            DocumentEditor._placeCursorAtEnd = True
 
         indent = bundle.objectForInfoDictionaryKey_('IndentWidth')
         if isinstance(indent, (int, long)):

--- a/README
+++ b/README
@@ -108,6 +108,11 @@ These can be set at the command line with the OS X defaults command:
     - configure MailWrap to strip the verbose date and time information
       from the attribution line when composing a reply. The default is on.
 
+  defaults write uk.me.cdw.MailWrap PlaceCursorAtEnd -bool { true | false }
+    - configure MailWrap to place the cursor at the end of the message
+      text for responding, after quoted text but before the signature,
+      if present.  The default is on.
+
   defaults write uk.me.cdw.MailWrap IndentWidth NN
     - configure MailWrap to increase/decrease plain text indentation by NN
       spaces when Command-] and Command-[ are used. The default is 2.

--- a/install.py
+++ b/install.py
@@ -28,6 +28,7 @@ setup(
             CFBundleIdentifier = 'uk.me.cdw.MailWrap',
             CFBundleVersion = '1.0',
             FixAttribution = True,
+            PlaceCursorAtEnd = True,
             NSHumanReadableCopyright = \
                 'Copyright (C) 2014 Chris Webb <chris@arachsys.com>',
             SupportedPluginCompatibilityUUIDs = compatibility_uuids,

--- a/install.py
+++ b/install.py
@@ -28,7 +28,7 @@ setup(
             CFBundleIdentifier = 'uk.me.cdw.MailWrap',
             CFBundleVersion = '1.0',
             FixAttribution = True,
-            PlaceCursorAtEnd = True,
+            PlaceCursorAtEnd = False,
             NSHumanReadableCopyright = \
                 'Copyright (C) 2014 Chris Webb <chris@arachsys.com>',
             SupportedPluginCompatibilityUUIDs = compatibility_uuids,


### PR DESCRIPTION
So the way I write mail is often, I hit "reply", then I actually read through the mail from the top down in terms of the quoted text, and add my comments inline.  So I like to still start at the top.

The one issue I'm having with the patch here is that the "defaults" thing isn't working on Maverick.  If I set `defaults write uk.me.cdw.MailWrap PlaceCursorAtEnd -bool false`, that puts the value in there, but that does not seem to be what `bundle.objectForInfoDictionaryKey_('PlaceCursorAtEnd')` is reading; all of those calls continue to read from what was set up in install.py.  Any tips on how this should work appreciated.