### PR TITLE
make sure to use system python

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ Installation
 MailWrap is currently compatible with Apple Mail 7.0 and later. To install,
 unpack the source tar.gz file, change to the unpacked directory and run
 
-  python install.py
+  /usr/bin/python install.py
 
 Plugin bundles contain a list of UUIDs identifying versions of Mail with
 which they are compatible. The install.py script extracts the correct UUID


### PR DESCRIPTION
Just a small change to the README. This is something that tripped me up on a system where `python` would call Homebrew's python, which lacks some of the required packages.